### PR TITLE
Fixing pip install error due to unsatisfied dependencies

### DIFF
--- a/Source/agsadmin/__init__.py
+++ b/Source/agsadmin/__init__.py
@@ -3,8 +3,5 @@
 Python Library used to provide conveniant access to administrative functions of ArcGIS Server 10.1.
 """
 
-__version__   = "0.1.2"
-__author__    =  "David Whittingham"
-__copyright__ = "Copyright (C) 2013 David Whittingham"
-
+from ._version import *
 from ._restadmin import RestAdmin

--- a/Source/agsadmin/_version.py
+++ b/Source/agsadmin/_version.py
@@ -1,0 +1,3 @@
+__version__   = "0.1.2"
+__author__    = "David Whittingham"
+__copyright__ = "Copyright (C) 2013 David Whittingham"

--- a/Source/setup.py
+++ b/Source/setup.py
@@ -1,10 +1,11 @@
-import agsadmin
-
 try:
     from setuptools import setup
 except ImportError:
     from distutils.core import setup
-	
+
+
+with open('agsadmin/_version.py') as fin: exec(fin)
+
 packages = [
     "agsadmin",
     "agsadmin.exceptions",
@@ -13,7 +14,7 @@ packages = [
 	
 setup(
     name = "agsadmin",
-    version = agsadmin.__version__,
+    version = __version__,
     packages = packages,
     
     #dependencies
@@ -28,7 +29,7 @@ setup(
     },
     
     #PyPI MetaData
-    author = agsadmin.__author__,
+    author = __author__,
     description = "ArcGIS Server REST Admin API Proxy",
     license = "BSD 3-Clause",
     keywords = "arcgis esri",

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,4 @@
+Set-Location "./Source"
+Invoke-Expression "python.exe setup.py sdist"
+Invoke-Expression "python.exe setup.py bdist_wheel"
+Set-Location "../"

--- a/buildWheel.bat
+++ b/buildWheel.bat
@@ -1,0 +1,3 @@
+@echo off
+cd Source
+python setup.py bdist_wheel

--- a/buildWheel.bat
+++ b/buildWheel.bat
@@ -1,3 +1,0 @@
-@echo off
-cd Source
-python setup.py bdist_wheel


### PR DESCRIPTION
Lemme know if this is all OK with you and I'll do the same to arcpyext and agstools (neither need it at the present, however)
